### PR TITLE
Adding new component to display the login and signup page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16448,7 +16448,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/src/Components/navbar.jsx
+++ b/src/Components/navbar.jsx
@@ -5,12 +5,12 @@ class Navbar extends Component {
   componentDidMount() {
     const toggleButton = document.querySelector(".toggle-button");
     const navbarLinks = document.getElementsByClassName("navbar-links")[0];
-    const activate=(navbarLinks)=> {
+    const activate = (navbarLinks) => {
       /* access all classes of navbarLinks and toggle the active class.
         If active class doesnt exist, it will add it and viceaversa. */
       navbarLinks.classList.toggle("active");
     }
-    toggleButton.addEventListener("click", ()=> {activate(navbarLinks)});
+    toggleButton.addEventListener("click", () => { activate(navbarLinks) });
   }
 
   render() {
@@ -45,6 +45,12 @@ class Navbar extends Component {
             </li>
             <li>
               <a href="/connect">Connect</a>
+            </li>
+            <li>
+              <a href="/login">Log in</a>
+            </li>
+            <li>
+              <a href="/signup">Sign up</a>
             </li>
           </ul>
         </div>

--- a/src/OtherPages/login.jsx
+++ b/src/OtherPages/login.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import "../styles/login.css";
+
+const LogComponent = (props) => {
+    const { isLogin, onClickCallback } = props;
+    const title = isLogin ? 'Log in your account' : 'Sign up';
+    const buttonText = isLogin ? 'Log in' : 'Sign up';
+    const emailRef = React.createRef();
+    const passwordRef = React.createRef();
+
+    const _handleClick = () => {
+        return onClickCallback(emailRef.current.value, passwordRef.current.value);
+    }
+
+    return (
+        <div className="registration-pane">
+            <h3>{title}</h3>
+            <p className="registration-attribute">Username or Email</p>
+            <input type="email" ref={emailRef} className="input-login" />
+            <p className="registration-attribute">Password</p>
+            <input type="password" ref={passwordRef} className="input-login" />
+            <button type="button" className="registration-button" onClick={_handleClick}>{buttonText}</button>
+        </div>
+    )
+
+}
+
+export default LogComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React, { lazy, Suspense } from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter, Switch, Route } from "react-router-dom";
 import Loader from "./Components/loader";
+import LogComponent from "./OtherPages/login";
 
 const MainApp = lazy(() => import("./MainApp"));
 const About = lazy(() => import("./OtherPages/About"));
@@ -25,6 +26,12 @@ const App = () => {
         </Route>
         <Route path="/about">
           <About></About>
+        </Route>
+        <Route path="/login">
+          <LogComponent isLogin={true} onClickCallback={() => { }} />
+        </Route>
+        <Route path="/signup">
+          <LogComponent isLogin={false} onClickCallback={() => { }} />
         </Route>
       </Switch>
     </Suspense>

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -1,0 +1,25 @@
+.registration-pane {
+  margin: 30px auto;
+  width: 350px;
+  display: flex;
+  flex-direction: column;
+  border-radius: 3px;
+  padding: 24px 10px !important;
+  background-color: rgb(250, 251, 252);
+}
+
+.registration-button {
+  background-color: rgb(46, 188, 79);
+  border-color: rgb(46, 188, 79);
+  font-weight: 500;
+  color: #fff;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  margin: 10px 0;
+}
+
+.registration-attribute{
+  display: inline-flex;
+  margin: 5px 0 10px;
+}


### PR DESCRIPTION
closes #3

It has been a new component that renders both, the log in and the sign up functionality.
![login](https://user-images.githubusercontent.com/32776999/135729716-cd718cdb-b1e0-4b1a-af74-e8bcc90764e6.png)
![signup](https://user-images.githubusercontent.com/32776999/135729720-9ad694eb-01b4-4ff5-8847-18d27aae8c1d.png)

It has been added two new accesses to the navbar.
![navbar](https://user-images.githubusercontent.com/32776999/135729723-152c8b60-f72f-4b89-b418-e229b6e1eb55.png)

The new compononent receives a prop calles `isLogin` that decides if it should show the login text, or the sign up comments.
